### PR TITLE
Use 'zip' gem instead of 'zipruby' to support RubyInstaller for Windows [i386-mingw32].

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,6 +6,8 @@
 
 make chromium extensions
 
+** Using 'zip' gem instead of 'zipruby' to support RubyInstaller for Windows.
+
 == SYNOPSIS:
 ruby code
   require 'crxmake'
@@ -62,7 +64,7 @@ command line
 == REQUIREMENTS:
 
 * openssl
-* zipruby
+* zip
 
 == INSTALL:
 

--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ spec = Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.test_files = Dir["test/*_test.rb"]
   {
-    "zipruby" => ">=0.3.2",
+    "zip" => "~> 2.0.2",
 #    "openssl" => ">=1.0.0"
   }.each do |dep, ver|
     s.add_dependency(dep, ver)

--- a/crxmake.gemspec
+++ b/crxmake.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{crxmake}
-  s.version = "2.0.3"
+  s.version = "2.0.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Constellation"]
-  s.date = %q{2010-04-28}
+  s.date = %q{2011-07-11}
   s.default_executable = %q{crxmake}
   s.description = %q{make chromium extension}
   s.email = %q{utatane.tea@gmail.com}
@@ -17,20 +17,19 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--main", "README.rdoc", "--charset", "utf-8", "--line-numbers", "--inline-source"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{crxmake}
-  s.rubygems_version = %q{1.3.6}
+  s.rubygems_version = %q{1.5.2}
   s.summary = %q{make chromium extension}
   s.test_files = ["test/crxmake_test.rb"]
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<zipruby>, [">= 0.3.2"])
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<zip>, ["~> 2.0.2"])
     else
-      s.add_dependency(%q<zipruby>, [">= 0.3.2"])
+      s.add_dependency(%q<zip>, ["~> 2.0.2"])
     end
   else
-    s.add_dependency(%q<zipruby>, [">= 0.3.2"])
+    s.add_dependency(%q<zip>, ["~> 2.0.2"])
   end
 end

--- a/lib/crxmake.rb
+++ b/lib/crxmake.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/ruby
 # vim: fileencoding=utf-8
 require 'rubygems'
-require 'zipruby'
+require 'zip'
 require 'openssl'
 require 'digest/sha1'
 require 'fileutils'
@@ -9,7 +9,7 @@ require 'find'
 require 'pathname'
 
 class CrxMake < Object
-  VERSION = '2.0.3'
+  VERSION = '2.0.4'
   # thx masover
   MAGIC = 'Cr24'
 
@@ -150,7 +150,7 @@ ext dir: \"#{@exdir}\"
 
   def create_zip
     puts "create zip" if @verbose
-    Zip::Archive.open(@zip, Zip::CREATE | Zip::TRUNC) do |zip|
+    Zip::ZipFile.open(@zip, Zip::ZipFile::CREATE) do |zip|
       Find.find(@exdir) do |path|
         unless path == @exdir
           if File.directory?(path)
@@ -159,14 +159,14 @@ ext dir: \"#{@exdir}\"
               Find.prune
             else
               puts "include dir: \"#{path}\"" if @verbose
-              zip.add_dir(get_relative(@exdir, path))
+              zip.add(get_relative(@exdir, path))
             end
           else
             if @ignorefile && File.basename(path) =~ @ignorefile
               puts "ignore file: \"#{path}\"" if @verbose
             else
               puts "include file: \"#{path}\"" if @verbose
-              zip.add_file(get_relative(@exdir, path), path)
+              zip.add(get_relative(@exdir, path), path)
             end
           end
         end


### PR DESCRIPTION
The zipruby gem has not been updated for the latest RubyInstaller for Windows and does not install with a simple gem install zipruby command or bundler. This makes depending on crxmake difficult. This change switches to using the zip gem which is a fork of the rubyzip gem added 1.9.1 compatibility (http://rubygems.org/gems/zip).

forest
