### PR TITLE
Depend on rubyzip, not zip

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,8 +6,6 @@
 
 make chromium extensions
 
-** Using 'zip' gem instead of 'zipruby' to support RubyInstaller for Windows.
-
 == SYNOPSIS:
 ruby code
   require 'crxmake'
@@ -64,7 +62,7 @@ command line
 == REQUIREMENTS:
 
 * openssl
-* zip
+* rubyzip
 
 == INSTALL:
 

--- a/crxmake.gemspec
+++ b/crxmake.gemspec
@@ -21,15 +21,5 @@ Gem::Specification.new do |s|
   s.summary = %q{make chromium extension}
   s.test_files = ["test/crxmake_test.rb"]
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<zip>, ["~> 2.0.2"])
-    else
-      s.add_dependency(%q<zip>, ["~> 2.0.2"])
-    end
-  else
-    s.add_dependency(%q<zip>, ["~> 2.0.2"])
-  end
+  s.add_runtime_dependency "rubyzip"
 end

--- a/lib/crxmake.rb
+++ b/lib/crxmake.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/ruby
 # vim: fileencoding=utf-8
 require 'rubygems'
-require 'zip'
+require 'zip/zip'
 require 'openssl'
 require 'digest/sha1'
 require 'fileutils'


### PR DESCRIPTION
The 'zip' gem is unmaintained and obsolete. 'rubzip' is
the most popular and best supported zip gem for ruby.
It supports Ruby 1.9 and Windows.
