### PR TITLE
Remove old zip file before making zip file.

### DIFF
--- a/lib/crxmake.rb
+++ b/lib/crxmake.rb
@@ -35,7 +35,7 @@ class CrxMake < Object
     sign_zip
     write_crx
   ensure
-    final
+    remove_zip
   end
 
   def zip
@@ -44,6 +44,7 @@ class CrxMake < Object
       generate_key
       @pkey = @pkey_o
     end
+    remove_zip
     create_zip do |zip|
       puts "include pem key: \"#{@pkey}\"" if @verbose
       zip.add('key.pem', @pkey)
@@ -214,7 +215,7 @@ zip file at \"#{@zip}\"
     return [num].pack('V')
   end
 
-  def final
+  def remove_zip
     FileUtils.rm_rf(@zip) if @zip && File.exist?(@zip)
   end
 


### PR DESCRIPTION
If old zip file exist, zip.rb throw Zip::ZipEntryExistsError. Therefore CrxMake.zip cannot make new zip file.
In order to solve this problem, add remove old zip file function, before making it.

Remove zip file function is already inpremented in code.(function name = final) But, function name 'final' is not suitable for not final place.
So, I rename final to remove_zip.
