### PR TITLE
Remove prefix bytes

### DIFF
--- a/lib/crxmake.rb
+++ b/lib/crxmake.rb
@@ -25,8 +25,6 @@ class CrxMake < Object
   # this is chromium extension version
   EXT_VERSION = [2].pack('V')
 
-  # CERT_PUBLIC_KEY_INFO struct
-  KEY = %w(30 81 9F 30 0D 06 09 2A 86 48 86 F7 0D 01 01 01 05 00 03 81 8D 00).map{|s| s.hex}.pack('C*')
   KEY_SIZE = 1024
 
   def initialize opt
@@ -212,7 +210,6 @@ zip file at \"#{@zip}\"
   def write_crx(zip_buffer)
     print "write crx..." if @verbose
     key = @key.public_key.to_der
-    key.index(KEY) != 0 and key = KEY + key
     File.open(@crx, 'wb') do |file|
       file << MAGIC
       file << EXT_VERSION


### PR DESCRIPTION
This is a "fix" for #18. I suspect it's wrong.

I couldn't get Chrome to accept my extension. I noticed that the CRXs that Chrome generates have 296-byte keys, but crxmake generates 316-byte keys because it tacks 22 bytes to the front of the key I provided. I removed the code that does that and now my extension works.

I _suspect_ what's happening is that my key is coming with the right ceremonial prefix in it, but that crxmake isn't recognizing it as "correct" and thus tacking on its own, thereby breaking things. Perhaps my fix breaks other things, such as keys generated by crxmake itself (I didn't try it). I don't really know how this stuff works, what the prefix really does, or why it would be constant (seems a bit odd).
